### PR TITLE
Add ability to host GWT module on a different domain than the site

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -91,7 +91,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	
 	public String getPreloaderBaseURL()
 	{
-		return GWT.getHostPageBaseURL() + "assets/";
+		return GWT.getModuleBaseURL().replace("/html", "") + "assets/";
 	}
 	
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -91,7 +91,10 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	
 	public String getPreloaderBaseURL()
 	{
-		return GWT.getModuleBaseURL().replace("/html", "") + "assets/";
+		String moduleUrl = GWT.getModuleBaseURL();
+		// Total Length - len("html") - len("/")
+		int correctLength = moduleUrl.length() - GWT.getModuleName().length() - 1;
+		return GWT.getModuleBaseURL().substring(0, correctLength) + "assets/";
 	}
 	
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -94,7 +94,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		String moduleUrl = GWT.getModuleBaseURL();
 		// Total Length - len("html") - len("/")
 		int correctLength = moduleUrl.length() - GWT.getModuleName().length() - 1;
-		return GWT.getModuleBaseURL().substring(0, correctLength) + "assets/";
+		return moduleUrl.substring(0, correctLength) + "assets/";
 	}
 	
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/AssetDownloader.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/AssetDownloader.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.backends.gwt.preloader;
 
 import com.badlogic.gdx.backends.gwt.preloader.AssetFilter.AssetType;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.ImageElement;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.typedarrays.shared.Int8Array;
@@ -143,7 +144,14 @@ public class AssetDownloader {
 	}
 
 	public void loadImage (final String url, final String mimeType, final AssetLoaderListener<ImageElement> listener) {
-		loadImage(url, mimeType, "anonymous", listener);
+		String crossOrigin = null;
+
+		// Enable CORS if we're running from a different URL to the host page
+		if (!url.startsWith(GWT.getHostPageBaseURL())) {
+			crossOrigin = "anonymous";
+		}
+
+		loadImage(url, mimeType, crossOrigin, listener);
 	}
 	
 	public void loadImage (final String url, final String mimeType, final String crossOrigin, final AssetLoaderListener<ImageElement> listener) {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/AssetDownloader.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/AssetDownloader.java
@@ -143,7 +143,7 @@ public class AssetDownloader {
 	}
 
 	public void loadImage (final String url, final String mimeType, final AssetLoaderListener<ImageElement> listener) {
-		loadImage(url, mimeType, null, listener);
+		loadImage(url, mimeType, "anonymous", listener);
 	}
 	
 	public void loadImage (final String url, final String mimeType, final String crossOrigin, final AssetLoaderListener<ImageElement> listener) {


### PR DESCRIPTION
This enables CORS/fixes some host page URL usage.

Main use case is hosting this in an S3 bucket for embedding in a thin React webapp.