### PR TITLE
Update to GDX 1.9.11-SNAPSHOT

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -111,7 +111,27 @@ public class AndroidGraphics implements Graphics, Renderer {
 		ResolutionStrategy resolutionStrategy) {
 		this(application, config, resolutionStrategy, true);
 	}
-
+	
+	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+	
 	public AndroidGraphics (AndroidApplicationBase application, AndroidApplicationConfiguration config,
 		ResolutionStrategy resolutionStrategy, boolean focusableView) {
 		this.config = config;

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
@@ -45,7 +45,39 @@ public class MockGraphics implements Graphics {
 	public GL20 getGL20() {
 		return null;
 	}
-
+	
+	/**
+	 * @return the inset from the left which avoids display cutouts in pixels
+	 */
+	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+	
+	/**
+	 * @return the inset from the top which avoids display cutouts in pixels
+	 */
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+	
+	/**
+	 * @return the inset from the bottom which avoids display cutouts or floating gesture bars, in pixels
+	 */
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+	
+	/**
+	 * @return the inset from the right which avoids display cutouts in pixels
+	 */
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+	
 	@Override
 	public void setGL20 (GL20 gl20) {
 

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -71,7 +71,27 @@ public class LwjglGraphics implements Graphics {
 	LwjglGraphics (LwjglApplicationConfiguration config) {
 		this.config = config;
 	}
-
+	
+	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+	
 	LwjglGraphics (Canvas canvas) {
 		this.config = new LwjglApplicationConfiguration();
 		config.width = canvas.getWidth();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -73,7 +73,27 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 			GLFW.glfwSwapBuffers(windowHandle);
 		}
 	};
-
+	
+	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+	
 	public Lwjgl3Graphics(Lwjgl3Window window) {
 		this.window = window;
 		if (window.getConfig().useGL30) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -181,7 +181,27 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	GLVersion glVersion;
 	GLKView view;
 	IOSUIViewController viewController;
-
+	
+	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+	
 	public IOSGraphics (float scale, IOSApplication app, IOSApplicationConfiguration config, IOSInput input, boolean useGLES30) {
 		this.config = config;
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -329,7 +329,27 @@ public class GwtGraphics implements Graphics {
 		return new DisplayMode((int) (getScreenWidthJSNI() * density),
 				(int) (getScreenHeightJSNI() * density), 60, 8) {};
 	}
-
+	
+	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+	
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+	
 	@Override
 	public boolean setFullscreenMode (DisplayMode displayMode) {
 		DisplayMode supportedMode = getDisplayMode();

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
@@ -7,10 +7,14 @@ import com.badlogic.gdx.Input.Keys;
 import com.google.gwt.user.client.Window.Navigator;
 
 public class UIUtils {
+	static public boolean isAndroid = Navigator.getPlatform().contains("Android");
 	static public boolean isMac = Navigator.getPlatform().contains("Mac");
 	static public boolean isWindows = Navigator.getPlatform().contains("Win");
 	static public boolean isLinux = Navigator.getPlatform().contains("Linux");
 
+	static public boolean isIos = Navigator.getPlatform().contains("iPhone")
+			|| Navigator.getPlatform().contains("iPod")
+			|| Navigator.getPlatform().contains("iPad");
 	static public boolean left () {
 		return Gdx.input.isButtonPressed(Buttons.LEFT);
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,14 @@ allprojects{
     }
 }
 
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}
+
 subprojects{
     apply plugin: "java"
     apply plugin: "maven"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
     testnatives = [:]
 }
 
-versions.gdx = "1.9.10"
+versions.gdx = "1.9.11-SNAPSHOT"
 versions.robovm = "2.3.6"
 versions.moe = "1.4.0"
 versions.gwt = "2.9.0"


### PR DESCRIPTION
Thanks @raeleus ! The 1.910.2 release is now permanently stored and JitPack knows about it, so the master revision will refer to 1.9.11-SNAPSHOT now (since it needs to be updated more often).